### PR TITLE
Add vunit.exportJsonOptions and append to the run.py --export-json call

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Property                              | Description
 `vunit.watch`                         | Watch run.py and test bench files for changes and reload tests automatically.
 `vunit.python`                        | Path to python executable.
 `vunit.flattenSingleLibrary`          | Flatten library hierarchy in explorer when all tests are contained within a single library.
-`vunit.options`                       | VUnit command line options.
-`vunit.guiOptions`                    | VUnit command line options when running GUI (-g should not be added here).
+`vunit.options`                       | VUnit run.py command line options when running tests.
+`vunit.guiOptions`                    | VUnit run.py command line options when running GUI (-g should not be added here).
 `testExplorer.onStart`                | Retire or reset all test states whenever a test run is started
 `testExplorer.onReload`               | Retire or reset all test states whenever the test tree is reloaded
 `testExplorer.codeLens`               | Show a CodeLens above each test or suite for running or debugging the tests

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Property                              | Description
 `vunit.flattenSingleLibrary`          | Flatten library hierarchy in explorer when all tests are contained within a single library.
 `vunit.options`                       | VUnit run.py command line options when running tests.
 `vunit.guiOptions`                    | VUnit run.py command line options when running GUI (-g should not be added here).
+`vunit.exportJsonOptions`             | VUnit run.py command line options when discovering test with --export-json.
 `testExplorer.onStart`                | Retire or reset all test states whenever a test run is started
 `testExplorer.onReload`               | Retire or reset all test states whenever the test tree is reloaded
 `testExplorer.codeLens`               | Show a CodeLens above each test or suite for running or debugging the tests

--- a/package.json
+++ b/package.json
@@ -61,12 +61,12 @@
                     "default": false
                 },
                 "vunit.options": {
-                    "description": "VUnit command line options.",
+                    "description": "VUnit run.py command line options when running tests.",
                     "type": "string",
                     "default": ""
                 },
                 "vunit.guiOptions": {
-                    "description": "VUnit command line options when running GUI, -g should not be added here.",
+                    "description": "VUnit run.py command line options when running GUI, -g should not be added here.",
                     "type": "string",
                     "default": ""
                 },

--- a/package.json
+++ b/package.json
@@ -70,6 +70,11 @@
                     "type": "string",
                     "default": ""
                 },
+                "vunit.exportJsonOptions": {
+                    "description": "VUnit run.py command line options when discovering test with --export-json.",
+                    "type": "string",
+                    "default": ""
+                },
                 "vunit.watch": {
                     "description": "Watch run.py and testbench files for changes and reload tests on save.",
                     "type": "boolean",

--- a/src/vunit.ts
+++ b/src/vunit.ts
@@ -276,8 +276,16 @@ function getWorkspaceRoot(): string | undefined {
 async function getVunitData(workDir: string): Promise<VunitExportData> {
     const vunitJson = path.join(workDir, `${uuid()}.json`);
     fs.mkdirSync(path.dirname(vunitJson), { recursive: true });
+
     let vunitData: VunitExportData = emptyVunitExportData;
-    await runVunit(['--list', `--export-json ${vunitJson}`])
+    let options = ['--list', `--export-json ${vunitJson}`];
+    const vunitExportJsonOptions = vscode.workspace
+        .getConfiguration()
+        .get('vunit.exportJsonOptions');
+    if (vunitExportJsonOptions) {
+        options.push(vunitExportJsonOptions as string);
+    }
+    await runVunit(options)
         .then(() => {
             vunitData = JSON.parse(fs.readFileSync(vunitJson, 'utf-8'));
             fs.unlinkSync(vunitJson);


### PR DESCRIPTION
So the use case is that I have a quite extensive ``run.py`` and I have to add some arguments to the call to make it work. This is possible for the test runs and GUI runs, but not for the --export-json run. This PR adds an option for this, much like for the other runs.

Disclaimer: I do not know how to build and test this. It is completely dry coded.