### PR TITLE
Quote VUnit JSON file path

### DIFF
--- a/src/vunit.ts
+++ b/src/vunit.ts
@@ -278,7 +278,7 @@ async function getVunitData(workDir: string): Promise<VunitExportData> {
     fs.mkdirSync(path.dirname(vunitJson), { recursive: true });
 
     let vunitData: VunitExportData = emptyVunitExportData;
-    let options = ['--list', `--export-json ${vunitJson}`];
+    let options = ['--list', `--export-json "${vunitJson}"`];
     const vunitExportJsonOptions = vscode.workspace
         .getConfiguration()
         .get('vunit.exportJsonOptions');


### PR DESCRIPTION
This makes extension work when the global storage path is inside
a directory containing spaces in its name (macOS).

Closes: #23.